### PR TITLE
ci: GitHub Action to pull from quarto-dev for automatic rendering

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,25 @@
-# .github/workflows/quarto-render.yml
-name: Render and deploy Quarto files
-on: 
+on:
   push:
-  pull_request:
+    branches: main
+
+name: Render and Publish
 
 jobs:
-  quarto-render-and-deploy:
+  build-deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - name: Check out repository
+        uses: actions/checkout@v2 
+        
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          tinytex: true 
 
-    - name: "Install Quarto and render"
-      uses: pommevilla/quarto-render@v0.3.11
-
+      - name: Publish to GitHub Pages (and render)
+        uses: quarto-dev/quarto-actions/publish@v2
+        with:
+          target: gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+      


### PR DESCRIPTION
## Edited `main.yml` to activate automated rendering via GitHub Actions

This *should* work since it worked in my fork

1. Push something to main branch (even an edit to README works).
2. Check Actions tab. Three actions will occur (if the first works, the remainder will)

To *really* verify, edit a quarto document and push it. There should be no need to render or build as the CI will build the doc through Linux

### Notes

- gh-pages branch **must** be present for this to work (so I just created one in the training template - note that it may cause a failed Action since one already exists before this pull request)
-  GitHub *should* automatically configure publishing through gh-pages when it sees the branch, but user may need to verify by going to Settings > Pages > Source: Deploy from branch
- future users should copy both main and gh-pages branches when copying the template

**If verified and working, will edit README to reflect new (easier) instructions**