### PR TITLE
Added publish instructions, cheatsheet.md

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -1,0 +1,3 @@
+# Quarto template cheatsheet
+
+Please contribute your tips, tricks for use, customisation of this template :)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ quarto publish
 
 Your Quarto project will be rendered at a URL with this format:
 ```html
-https://sydney-informatics-hub.github.io/<NAME-OF-YOUR-REPO>/
+https://pages.github.sydney.edu.au/informatics/<NAME-OF-YOUR-REPO>/
 ```
 
 ### GitHub Actions 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,33 @@ The building from Jupyter notebooks will NOT re-render all of the notebooks unle
 3. Add links to your content to the navigation configuration in `_quarto.yml`. For example, to link to the rendered page for `notebooks/1_cont.md`, add a link to `notebooks/1_cont.html` in `_quarto.yml`
 4. Type `quarto render` in the terminal - or use VSCode's "Render Quarto project' command using the command pallette instead.
 
+## Publish with GitHub pages
 
-***
+To publish Quarto websites to GitHub pages, you can:
+* Render sites on your local machine (see above)
+* Use the `quarto publish` command
+* Use [GitHub Actions](https://github.com/quarto-dev/quarto-actions)
 
+### Quarto publish command
+
+Enable GitHub pages in your repository settings:
+* Go to GitHub repository settings 
+* Scroll down to "GitHub Pages" section and select the following: 
+    * `Source: deploy from a branch`
+    * `Branch:gh-pages`
+    * `Save`
+
+Run the quarto publish command (assuming you are working in terminal) 
+```
+quarto publish
+```
+
+Your Quarto project will be rendered at a URL with this format:
+```html
+https://sydney-informatics-hub.github.io/<NAME-OF-YOUR-REPO>/
+```
+
+### GitHub Actions 
+TBC
+ 
 # Examples of template use, with GitHub actions

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Enable GitHub pages in your repository settings:
 * Go to GitHub repository settings 
 * Scroll down to "GitHub Pages" section and select the following: 
     * `Source: deploy from a branch`
-    * `Branch:gh-pages`
+    * `Branch:main`
+      * `Directory: /root`
     * `Save`
 
 Run the quarto publish command (assuming you are working in terminal) 


### PR DESCRIPTION
- CLI instructions for rendering and publishing to GitHub pages 
- Can add GitHub Actions instructions to README once https://github.com/Sydney-Informatics-Hub/training-template/pull/1 is approved
- Created CHEATSHEET for tidbits, resources sharing by template users
